### PR TITLE
Fixes difference in atmos from tiles for lava and ice planets, and fi…

### DIFF
--- a/code/datums/planet_loader/earthlike.dm
+++ b/code/datums/planet_loader/earthlike.dm
@@ -57,7 +57,7 @@
 					closest_dist = dist
 			if(closest)
 				var/datum/biome/B = closest.biome
-				T.ChangeTurf(B.turf_type)
+				T.ChangeTurf(B.turf_type,null,FALSE,TRUE)
 				B.turfs += T
 				if(istype(T,/turf/open))
 					if(B.flora_density && B.flora_types)

--- a/code/game/turfs/simulated/floor/misc_floor.dm
+++ b/code/game/turfs/simulated/floor/misc_floor.dm
@@ -88,6 +88,7 @@
 	icon = 'icons/turf/snow.dmi'
 	icon_state = "ice"
 	temperature = 180
+	initial_gas_mix = "o2=22;n2=82;TEMP=180"
 	baseturf = /turf/open/floor/plating/ice
 	no_shuttle_move = 1
 	slowdown = 1
@@ -96,11 +97,11 @@
 /turf/open/floor/plating/ice/surface
 	planetary_atmos = TRUE
 
-/turf/open/floor/plating/ice/break_tile()
-	return
+/turf/open/floor/plating/ice/colder
+	temperature = 140
 
-/turf/open/floor/plating/ice/surface
-	planetary_atmos = TRUE
+/turf/open/floor/plating/ice/temperate
+	temperature = 255.37
 
 /turf/open/floor/plating/ice/break_tile()
 	return

--- a/code/game/turfs/simulated/floor/planet_floor.dm
+++ b/code/game/turfs/simulated/floor/planet_floor.dm
@@ -1,6 +1,7 @@
 /turf/open/floor/plating/asteroid/planet
 	icon = 'icons/turf/floors/planet.dmi'
 	planetary_atmos = TRUE
+	initial_gas_mix = "o2=22;n2=82;TEMP=293.15"
 	baseturf = /turf/open/floor/plating/asteroid/planet/sand
 	smooth = SMOOTH_TRUE | SMOOTH_CUSTOM
 	var/edge_layer = 0
@@ -104,6 +105,7 @@
 	name = "ungenerated turf"
 	desc = "If you see this, and you're not a ghost, yell at coders"
 	environment_type = "genturf"
+	//initial_gas_mix = "o2=22;n2=82;TEMP=293.15"
 	icon_state = "genturf_0"
 	edge_layer = 10000 // No edges on this turf. Ever.
 	variant_amount = 1

--- a/code/game/turfs/simulated/floor/plating/asteroid.dm
+++ b/code/game/turfs/simulated/floor/plating/asteroid.dm
@@ -353,4 +353,5 @@
 	initial_gas_mix = "o2=22;n2=82;TEMP=180"
 
 /turf/open/floor/plating/asteroid/snow/surface
+	initial_gas_mix = "o2=22;n2=82;TEMP=180"
 	planetary_atmos = TRUE

--- a/code/game/turfs/simulated/floor/plating/misc_plating.dm
+++ b/code/game/turfs/simulated/floor/plating/misc_plating.dm
@@ -121,30 +121,6 @@
 /turf/open/floor/plating/ironsand/burn_tile()
 	return
 
-
-/turf/open/floor/plating/ice
-	name = "ice sheet"
-	desc = "A sheet of solid ice. Looks slippery."
-	icon = 'icons/turf/snow.dmi'
-	icon_state = "ice"
-	temperature = 180
-	baseturf = /turf/open/floor/plating/ice
-	slowdown = 1
-	wet = TURF_WET_PERMAFROST
-
-/turf/open/floor/plating/ice/colder
-	temperature = 140
-
-/turf/open/floor/plating/ice/temperate
-	temperature = 255.37
-
-/turf/open/floor/plating/ice/break_tile()
-	return
-
-/turf/open/floor/plating/ice/burn_tile()
-	return
-
-
 /turf/open/floor/plating/snowed
 	name = "snowed-over plating"
 	desc = "A section of plating covered in a light layer of snow."

--- a/code/game/turfs/simulated/lava.dm
+++ b/code/game/turfs/simulated/lava.dm
@@ -5,6 +5,7 @@
 	icon_state = "lava"
 	gender = PLURAL //"That's some lava."
 	baseturf = /turf/open/lava //lava all the way down
+	initial_gas_mix = LAVALAND_DEFAULT_ATMOS
 	slowdown = 2
 
 	light_range = 2


### PR DESCRIPTION
…xes some parts of habitable planets starting atmos too early, resulting in 40k active tiles.

[Changelogs]: # (Please make a changelog if you're adding, removing or changing content that'll affect players. This includes, but is not limited to, new features, sprites, sounds; balance changes; map edits and important fixes)
[]: # (See here for how to easily make a changelog: https://github.com/tgstation/tgstation/wiki/Changelogs. An example changelog has been provided below. Please edit or remove)


:cl: optional name here
add: Added new things
add: Added more things
del: Removed old things
tweak: tweaked a few things
balance: rebalanced something
fix: fixed a few things
wip: added a few works in progress
soundadd: added a new sound thingy
sounddel: removed an old sound thingy
imageadd: added some icons and images
imagedel: deleted some icons and images
spellcheck: fixed a few typos
experiment: added an experimental thingy
/:cl:

[why]: # (Please add a short description [on the next line] of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding:) 
